### PR TITLE
Add upper bound on base-compat

### DIFF
--- a/regex.cabal
+++ b/regex.cabal
@@ -177,7 +177,7 @@ Library
     Build-depends:
         array                >= 0.4
       , base                 >= 4        && <  5
-      , base-compat          >= 0.6
+      , base-compat          >= 0.6      && <  0.11
       , bytestring           == 0.10.*
       , containers           >= 0.4
       , hashable             == 1.2.*


### PR DESCRIPTION
base-compat 0.11 moves 'fail' into 'MonadFail'

This breaks the build of Text.RE.ZeInternals.SearchReplace.compileSearchReplace_

Could you also add upper bounds to the released versions on hackage?